### PR TITLE
Graphql schema update

### DIFF
--- a/demo/server/models/db.js
+++ b/demo/server/models/db.js
@@ -7,12 +7,13 @@ const pool = new Pool({
   connectionString: PG_URI,
 });
 
-module.exports = {
+const db = {
   query: function (queryString, params, callback) {
     console.log(`Executed query: ${queryString}`);
     return pool.query(queryString, params, callback);
   },
 };
+export default db;
 
 /*
 https://riptutorial.com/sql/example/4978/library-database


### PR DESCRIPTION
GraphQL Schema updated to use type relations
GenreType added
addGenre, deleteGenre, updateBook, updateAuthor, deleteBook created or modified and all seem to be working
Changed export.modules to export default in db.js to allow for import in schema.ts

Typescript typing still needed in schema.
Querying for all books with authors and genres causes psql error: too many connections for role 